### PR TITLE
Upgrade StlyeCop to 4.7.54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Stylecop Repository
+stylecop/
 # NuGet Packages
 *.nupkg
 # The packages folder can be ignored because of Package Restore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
 solution: StyleCop.Baboon.sln
 install:
+  - hg clone https://hg.codeplex.com/stylecop
   - nuget restore StyleCop.Baboon.sln
   - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
 script:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ StyleCop.Baboon helps you to fix [StyleCop](https://stylecop.codeplex.com/) prob
 
 ## <a name="installation"></a>Installation / Usage
 
-1. Clone this repository and build the solution.
+1. Clone this repository and clone/download the StyleCop repository
+
+    To download StyleCop go to its [web](https://stylecop.codeplex.com/SourceControl/latest) and click in *Download*.
+    Then unzip and rename the folder to just *stylecop*.
+
+    To clone StyleCop repository (Mercurial):
+    ```sh
+    hg clone https://hg.codeplex.com/stylecop
+    ```
+
+2. Build the solution.
 
     On Windows:
 
@@ -22,13 +32,13 @@ StyleCop.Baboon helps you to fix [StyleCop](https://stylecop.codeplex.com/) prob
     $ xbuild "StyleCop.Baboon.sln"
     ```
 
-2. Use your custom StyleCop settings to analyze a file or a directory. This will generate ```StyleCopViolations.xml``` file.
+3. Use your custom StyleCop settings to analyze a file or a directory. This will generate ```StyleCopViolations.xml``` file.
 
     ```
     $ [mono] StyleCop.Baboon.exe Settings.StyleCop StyleCop.Baboon/Program.cs
     ```
 
-3. Fix StyleCop's complaints and stay on the line to avoid more complaints.
+4. Fix StyleCop's complaints and stay on the line to avoid more complaints.
 
 ## Global installation of StyleCop.Baboon (Linux only)
 

--- a/StyleCop.Baboon/StyleCop.Baboon.csproj
+++ b/StyleCop.Baboon/StyleCop.Baboon.csproj
@@ -18,7 +18,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>full</DebugType>
@@ -28,7 +27,6 @@
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
     <PlatformTarget>x86</PlatformTarget>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Optimize>false</Optimize>
@@ -48,13 +46,13 @@
       <HintPath>..\library\Microsoft.Build.Framework.dll</HintPath>
     </Reference>
     <Reference Include="StyleCop.CSharp">
-      <HintPath>..\packages\StyleCop.Rules.4.7.49\lib\net40\StyleCop.CSharp.dll</HintPath>
+      <HintPath>..\stylecop\Tools\StyleCop\v4.7\StyleCop.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="StyleCop.CSharp.Rules">
-      <HintPath>..\packages\StyleCop.Rules.4.7.49\lib\net40\StyleCop.CSharp.Rules.dll</HintPath>
+      <HintPath>..\stylecop\Tools\StyleCop\v4.7\StyleCop.CSharp.Rules.dll</HintPath>
     </Reference>
     <Reference Include="StyleCop">
-      <HintPath>..\packages\StyleCop.Rules.4.7.49\lib\net40\StyleCop.dll</HintPath>
+      <HintPath>..\stylecop\Tools\StyleCop\v4.7\StyleCop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -75,9 +73,6 @@
     <Compile Include="Renderer\StandardOutputWriter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <ItemGroup>
     <Folder Include="Analyzer\" />
     <Folder Include="Analyzer\StyleCop\" />

--- a/StyleCop.Baboon/packages.config
+++ b/StyleCop.Baboon/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="StyleCop" version="4.7.49.0" targetFramework="net45" />
-  <package id="StyleCop.Rules" version="4.7.49" targetFramework="net45" />
-</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 version: 1.0.{build}
 before_build:
-- cmd: nuget restore
+- cmd: >-
+    hg clone https://hg.codeplex.com/stylecop
+
+    nuget restore
 build:
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,3 +7,6 @@ before_build:
 build:
   verbosity: minimal
   project: StyleCop.Baboon.sln
+test:
+  assemblies: StyleCop.Baboon.Tests\bin\Debug\StyleCop.Baboon.Tests.dll
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,3 +6,4 @@ before_build:
     nuget restore
 build:
   verbosity: minimal
+  project: StyleCop.Baboon.sln


### PR DESCRIPTION
StyleCop is still at [4.7.49 in NuGet](https://www.nuget.org/packages/StyleCop/) (2014) and it doesn't support new C# 6 features like constant properties. I have modified the README and project files to use the latest (4.7.54 from May 2016) DLLs from the [StyleCop repository](https://stylecop.codeplex.com/).
