### PR TITLE
Use GitHub StyleCop repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# Stylecop Repository
-stylecop/
 # NuGet Packages
 *.nupkg
 # The packages folder can be ignored because of Package Restore

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "StyleCop"]
+	path = StyleCop
+	url = https://github.com/StyleCop/StyleCop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: csharp
 solution: StyleCop.Baboon.sln
 install:
-  - hg clone https://hg.codeplex.com/stylecop
   - nuget restore StyleCop.Baboon.sln
   - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
 script:
-  - xbuild /p:Configuration=Release StyleCop.Baboon.sln
+  - msbuild /p:Configuration=Release StyleCop.Baboon.sln
   - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./StyleCop.Baboon.Tests/bin/Release/StyleCop.Baboon.Tests.dll
 mono:
   - latest

--- a/README.md
+++ b/README.md
@@ -6,41 +6,22 @@ StyleCop.Baboon helps you to fix [StyleCop](https://stylecop.codeplex.com/) prob
 
 ## <a name="installation"></a>Installation / Usage
 
-1. Clone this repository
+1. Clone this repository with '--recursive' flag or run 'git submodule update --init' to clone the StyleCop submodule too.
 
-2. From inside the root of the this repository, clone/download the StyleCop repository into a subfolder called `stylecop`.
+2. Build the solution.
 
-    * To download StyleCop go to its [web](https://stylecop.codeplex.com/SourceControl/latest) and click in *Download*. Then unzip and rename the folder to just *stylecop*.
+```sh
+$ nuget restore
+$ msbuild "StyleCop.Baboon.sln"
+```
 
-    * To clone StyleCop repository (Mercurial only):
-
-        ```sh
-        hg clone https://hg.codeplex.com/stylecop
-        ```
-
-3. Build the solution.
-
-    * On Windows:
-
-        ```sh
-        $ nuget restore
-        $ msbuild "StyleCop.Baboon.sln"
-        ```
-
-    * On Linux and OSX after you have installed [Mono](http://www.mono-project.com/download/):
-
-        ```sh
-        $ nuget restore
-        $ xbuild "StyleCop.Baboon.sln"
-        ```
-
-4. Use your custom StyleCop settings to analyze a file or a directory. This will generate ```StyleCopViolations.xml``` file.
+3. Use your custom StyleCop settings to analyze a file or a directory. This will generate ```StyleCopViolations.xml``` file.
 
     ```
     $ [mono] StyleCop.Baboon.exe Settings.StyleCop StyleCop.Baboon/Program.cs
     ```
 
-5. Enjoy! Fix StyleCop's complaints and stay on the line to avoid more complaints.
+4. Enjoy! Fix StyleCop's complaints and stay on the line to avoid more complaints.
 
 ## Global installation of StyleCop.Baboon (Linux only)
 

--- a/StyleCop.Baboon/StyleCop.Baboon.csproj
+++ b/StyleCop.Baboon/StyleCop.Baboon.csproj
@@ -46,13 +46,13 @@
       <HintPath>..\library\Microsoft.Build.Framework.dll</HintPath>
     </Reference>
     <Reference Include="StyleCop.CSharp">
-      <HintPath>..\stylecop\Tools\StyleCop\v4.7\StyleCop.CSharp.dll</HintPath>
+      <HintPath>..\StyleCop\Tools\StyleCop\StyleCop.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="StyleCop.CSharp.Rules">
-      <HintPath>..\stylecop\Tools\StyleCop\v4.7\StyleCop.CSharp.Rules.dll</HintPath>
+      <HintPath>..\StyleCop\Tools\StyleCop\StyleCop.CSharp.Rules.dll</HintPath>
     </Reference>
     <Reference Include="StyleCop">
-      <HintPath>..\stylecop\Tools\StyleCop\v4.7\StyleCop.dll</HintPath>
+      <HintPath>..\StyleCop\Tools\StyleCop\StyleCop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 version: 1.0.{build}
 before_build:
 - cmd: >-
-    hg clone https://hg.codeplex.com/stylecop
-
     nuget restore
 build:
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: 1.0.{build}
 before_build:
 - cmd: >-
+    git submodule update --init --recursive
+
     nuget restore
 build:
   verbosity: minimal


### PR DESCRIPTION
CodePlex is shutting down. The StyleCop project was moved to a GitHub repo. This PR updates any reference for CodePlex and simply the instructions by using submodules instead of cloning manually the repo.